### PR TITLE
Update OBJ import API for Blender 4.0 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -128,7 +128,10 @@ class BlenderGen:
             if texture_path:
                 texture_path = glob.glob(filepath + "/*.png")[0]
 
-        bpy.ops.import_scene.obj(filepath=file_path, axis_forward="Y", axis_up="Z")
+        if bpy.app.version[0] >= 4:
+            bpy.ops.wm.obj_import(filepath=file_path, forward_axis="Y", up_axis="Z")
+        else:
+            bpy.ops.import_scene.obj(filepath=file_path, axis_forward="Y", axis_up="Z")
         print("importing model with axis_forward=Y, axis_up=Z")
 
         obj_objects = bpy.context.selected_objects[:]


### PR DESCRIPTION
This PR updates the OBJ import functionality to ensure compatibility with Blender 4.0 and above. Blender 4.0 introduces a change in the API for importing OBJ files, switching from `bpy.ops.import_scene.obj` to `bpy.ops.wm.obj_import`.

**Changes:**
- Implemented a version check to switch between the old and new API based on the Blender version.
- Ensured that the code remains compatible with Blender 3.x and earlier versions.

**Reference:**
- [Blender 4.0 Python API Changelog: Import/Export](https://developer.blender.org/docs/release_notes/4.0/python_api/#importexport)

---

I would also like to take this opportunity to express my gratitude for making this repository publicly available. It has been incredibly valuable, and I’m glad to be able to contribute to its development.

Please review the changes and let me know if any adjustments are needed.